### PR TITLE
Makefile examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,16 @@ _test_self_test.sh: test.sh
 testutil.o: testutil.c aqcc.h
 	gcc -c testutil.c -o testutil.o
 
-clean:
-	rm $(SELF_OBJS)
-	rm $(SELF_ASSEMBLES)
-	rm _test_self_test.sh
-	rm $(TARGET) $(TARGET_SELF)
+examples: $(TARGET)
+	make -C examples
 
-.PHONY: test self self_test test clean
+clean:
+	make -C examples $@
+	rm -f $(SELF_OBJS)
+	rm -f $(SELF_ASSEMBLES)
+	rm -f _test_self_test.sh
+	rm -f $(TARGET) $(TARGET_SELF)
+
+.PHONY: test self self_test test clean examples
 
 .PRECIOUS: %.self.s

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,7 @@
+nqueen:
+	make -C $@
+
+clean: 
+	make -C nqueen $@
+
+.PHONY: nqueen

--- a/examples/nqueen/Makefile
+++ b/examples/nqueen/Makefile
@@ -1,0 +1,16 @@
+CC=../../aqcc_self
+
+TARGET=nqueen
+SRC=main.c
+ASSEMBLES=$(SRC:.c=.s)
+
+$(TARGET) : $(ASSEMBLES)
+	gcc $^ -o $@
+
+%.s : %.c
+	$(CC) $< > $@
+
+clean:
+	rm -f $(TARGET) $(ASSEMBLES)
+
+.PHONY: clean

--- a/examples/nqueen/Makefile
+++ b/examples/nqueen/Makefile
@@ -1,4 +1,5 @@
-CC=../../aqcc_self
+# AQCC
+AQCC=../../aqcc
 
 TARGET=nqueen
 SRC=main.c
@@ -8,7 +9,7 @@ $(TARGET) : $(ASSEMBLES)
 	gcc $^ -o $@
 
 %.s : %.c
-	$(CC) $< > $@
+	$(AQCC) $< > $@
 
 clean:
 	rm -f $(TARGET) $(ASSEMBLES)


### PR DESCRIPTION
Example用のMakefile を追加しました.
```
$ pushd aqcc/
$ make examples
```
を実行すると、 `aqcc` により、`nqueen` がコンパイルされます.
また、(申し訳ありませんが) `make clean` のときに、削除すべき実行ファイルが存在しなくとも エラーが出ないようにもしました.