### PR TITLE
Add current working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,18 +51,16 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-# written by anqou
+# written for aqcc
 _test*
 *.~*~
 main
 aqcc_detail
-
-# written by hiromi-mi
 *.self.s
 *.selfself.s
 tags
-aqcc_self
-aqcc_selfself
+aqcc_self_detail
+aqcc_selfself_detail
 examples/nqueen/main.s
 examples/nqueen/nqueen
 __self_sort.in

--- a/aqcc
+++ b/aqcc
@@ -2,7 +2,8 @@
 
 if [ -z $AQCC_DETAIL ]
 then
-    AQCC_DETAIL=./aqcc_detail
+    # Use aqcc_detail located in the directory including this script.
+    AQCC_DETAIL=`dirname ${0}`/aqcc_detail
 fi
 
 function print_usage_to_fail() {

--- a/aqcc.h
+++ b/aqcc.h
@@ -36,7 +36,6 @@ int fputc(int c, FILE *stream);
 int fgetc(FILE *stream);
 int fprintf(FILE *stream, const char *format, ...);
 int printf(const char *format, ...);
-int sprintf(char *str, const char *format, ...);
 int vsprintf(char *str, const char *format, va_list ap);
 #define EXIT_FAILURE 1 /* Failing exit status.  */
 #define EXIT_SUCCESS 0 /* Successful exit status.  */

--- a/aqcc.h
+++ b/aqcc.h
@@ -80,6 +80,15 @@ char string_builder_append(StringBuilder *sb, char ch);
 char *string_builder_get(StringBuilder *sb);
 int string_builder_size(StringBuilder *sb);
 
+typedef struct {
+    int line, column;
+    Vector *line2length;
+    char *src;
+    // example: "/tmp/1.c" -> cwd: "/tmp/"
+    char *cwd;  // current working directory with '/'
+    char *filepath;
+} Source;
+
 enum {
     tINT,
     tSTRING_LITERAL,
@@ -160,7 +169,8 @@ enum {
 };
 
 typedef struct {
-    int kind, line, column;
+    int kind;
+    Source *source;
 
     union {
         int ival;
@@ -574,15 +584,6 @@ Code *str2reg(char *src);
 void erase_backslash_newline(char *src);
 
 // lex.c
-typedef struct {
-    int line, column;
-    Vector *line2length;
-    char *src;
-    // example: "/tmp/1.c" -> cwd: "/tmp/"
-    char *cwd;  // current working directory with '/'
-    char *filepath;
-} Source;
-
 Vector *read_all_tokens(char *src, char *filepath);
 const char *token_kind2str(int kind);
 Vector *concatenate_string_literal_tokens(Vector *tokens);
@@ -713,7 +714,7 @@ Vector *get_gvar_list();
 Vector *preprocess_tokens(Vector *tokens);
 
 // token.c
-Token *new_token(int kind, int line, int column);
+Token *new_token(int kind, Source *source);
 Token *clone_token(Token *src);
 TokenSeq *new_token_seq(Vector *tokens);
 void init_tokenseq(Vector *tokens);

--- a/aqcc.h
+++ b/aqcc.h
@@ -36,6 +36,7 @@ int fputc(int c, FILE *stream);
 int fgetc(FILE *stream);
 int fprintf(FILE *stream, const char *format, ...);
 int printf(const char *format, ...);
+int sprintf(char *str, const char *format, ...);
 int vsprintf(char *str, const char *format, va_list ap);
 #define EXIT_FAILURE 1 /* Failing exit status.  */
 #define EXIT_SUCCESS 0 /* Successful exit status.  */
@@ -574,10 +575,19 @@ Code *str2reg(char *src);
 void erase_backslash_newline(char *src);
 
 // lex.c
-Vector *read_all_tokens(char *src);
+typedef struct {
+    int line, column;
+    Vector *line2length;
+    char *src;
+    // example: "/tmp/1.c" -> cwd: "/tmp/"
+    char *cwd;  // current working directory with '/'
+    char *filepath;
+} Source;
+
+Vector *read_all_tokens(char *src, char *filepath);
 const char *token_kind2str(int kind);
 Vector *concatenate_string_literal_tokens(Vector *tokens);
-Vector *read_all_asm(char *src);
+Vector *read_all_asm(char *src, char *filepath);
 
 // parse.c
 Vector *parse_prog(Vector *tokens);

--- a/cpp.c
+++ b/cpp.c
@@ -36,9 +36,8 @@ extern Source source;  // To get source.cwd. Declared in lex.c
 
 void preprocess_tokens_detail_include()
 {
-    char include_filepath[512];  // enough length?
-    sprintf(include_filepath, "%s%s", source.cwd,
-            expect_token(tSTRING_LITERAL)->sval);
+    char *include_filepath =
+        format("%s%s", source.cwd, expect_token(tSTRING_LITERAL)->sval);
     expect_token(tNEWLINE);
     insert_tokens(read_tokens_from_filepath(include_filepath));
 }

--- a/cpp.c
+++ b/cpp.c
@@ -32,12 +32,10 @@ void preprocess_tokens_detail_define()
     add_define(name, tokens);
 }
 
-extern Source source;  // To get source.cwd. Declared in lex.c
-
 void preprocess_tokens_detail_include()
 {
-    char *include_filepath =
-        format("%s%s", source.cwd, expect_token(tSTRING_LITERAL)->sval);
+    Token *token = expect_token(tSTRING_LITERAL);
+    char *include_filepath = format("%s%s", token->source->cwd, token->sval);
     expect_token(tNEWLINE);
     insert_tokens(read_tokens_from_filepath(include_filepath));
 }

--- a/cpp.c
+++ b/cpp.c
@@ -32,11 +32,15 @@ void preprocess_tokens_detail_define()
     add_define(name, tokens);
 }
 
+extern Source source;  // To get source.cwd. Declared in lex.c
+
 void preprocess_tokens_detail_include()
 {
-    char *filepath = expect_token(tSTRING_LITERAL)->sval;
+    char include_filepath[512];  // enough length?
+    sprintf(include_filepath, "%s%s", source.cwd,
+            expect_token(tSTRING_LITERAL)->sval);
     expect_token(tNEWLINE);
-    insert_tokens(read_tokens_from_filepath(filepath));
+    insert_tokens(read_tokens_from_filepath(include_filepath));
 }
 
 void preprocess_tokens_detail_ifdef_ifndef(const char *keyword)

--- a/examples/nqueen/Makefile
+++ b/examples/nqueen/Makefile
@@ -1,20 +1,14 @@
 # AQCC
-AQCC=../../aqcc_detail
+AQCC=../../aqcc
 
 TARGET=nqueen
 SRC=main.c
 OBJS=$(SRC:.c=.o)
 
-$(TARGET) : $(OBJS)
-	gcc $^ -o $@
-
-%.s : %.c
-	$(AQCC) cs $< $@
-
-%.o : %.s
-	$(AQCC) so $< $@
+$(TARGET) : $(SRC) ../../system.s ../../stdlib.c
+	$(AQCC) $^  -o $@
 
 clean:
-	rm -f $(TARGET) $(ASSEMBLES)
+	rm -f $(TARGET) $(ASSEMBLES) $(OBJS)
 
 .PHONY: clean

--- a/lex.c
+++ b/lex.c
@@ -7,7 +7,7 @@ void init_source(char *src, char *filepath)
     // caluculate current working directory
     int i, j, len = strlen(filepath);
     source.cwd = safe_malloc(sizeof(char *) * len);
-    // ad-hoc
+    // TODO: ad-hoc
     for (i = len - 1; i >= 0; i--) {
         if (filepath[i] == '/') {
             // detect last '/'
@@ -40,7 +40,9 @@ void init_source(char *src, char *filepath)
 
 Token *make_token(int kind)
 {
-    return new_token(kind, source.line, source.column);
+    Source *src = (Source *)safe_malloc(sizeof(Source));
+    memcpy(src, &source, sizeof(Source));
+    return new_token(kind, src);
 }
 
 void ungetch()

--- a/lex.c
+++ b/lex.c
@@ -1,14 +1,29 @@
 #include "aqcc.h"
 
-typedef struct {
-    int line, column;
-    Vector *line2length;
-    char *src;
-} Source;
 Source source;
 
-void init_source(char *src)
+void init_source(char *src, char *filepath)
 {
+    // caluculate current working directory
+    int i, j, len = strlen(filepath);
+    source.cwd = safe_malloc(sizeof(char *) * len);
+    // ad-hoc
+    for (i = len - 1; i >= 0; i--) {
+        if (filepath[i] == '/') {
+            // detect last '/'
+            for (j = 0; j <= i; j++) {
+                source.cwd[j] = filepath[j];
+            }
+            source.cwd[i + 1] = '\0';
+            break;
+        }
+    }
+    // When this source code and aqcc are located in the same directory
+    if (source.cwd[0] == '\0') {
+        strcpy(source.cwd, "./");
+    }
+
+    source.filepath = filepath;
     source.src = src;
     source.line = source.column = 1;
     source.line2length = new_vector();
@@ -374,7 +389,8 @@ Token *read_next_token()
                     return make_token(tDOT);
                 }
                 if (getch() != '.')
-                    error(":%d:%d: unexpected dot", source.line, source.column);
+                    error("%s:%d:%d: unexpected dot", source.filepath,
+                          source.line, source.column);
                 return make_token(tDOTS);  // ...
 
             case '{':
@@ -405,17 +421,18 @@ Token *read_next_token()
                 return make_token(tNEWLINE);
         }
 
-        error(format("%d:%d:unexpected character", source.line, source.column));
+        error(format("%s:%d:%d:unexpected character", source.filepath,
+                     source.line, source.column));
     }
 
     return make_token(tEOF);
 }
 
-Vector *read_all_tokens(char *src)
+Vector *read_all_tokens(char *src, char *filepath)
 {
     erase_backslash_newline(src);
 
-    init_source(src);
+    init_source(src, filepath);
 
     Vector *tokens = new_vector();
     while (1) {
@@ -650,8 +667,8 @@ char sgetch()
 
 _Noreturn void unexpected_char_error(char expect, char got)
 {
-    error("%d:%d: unexpected character: expect %c, got %c", source.line,
-          source.column, expect, got);
+    error("%s:%d:%d: unexpected character: expect %c, got %c", source.filepath,
+          source.line, source.column, expect, got);
 }
 
 char sexpect_ch(char expect)
@@ -718,9 +735,9 @@ Code *read_asm_param()
     return new_addrof_label_code(read_asm_memory(), label);
 }
 
-Vector *read_all_asm(char *src)
+Vector *read_all_asm(char *src, char *filepath)
 {
-    init_source(src);
+    init_source(src, filepath);
 
     Vector *code = new_vector();
 
@@ -850,8 +867,8 @@ Vector *read_all_asm(char *src)
             continue;
         }
 
-        error(":%d:%d: not implemented assembly: %s", source.line,
-              source.column, str);
+        error("%s:%d:%d: not implemented assembly: %s", source.filepath,
+              source.line, source.column, str);
     }
 
     return code;

--- a/stdlib.c
+++ b/stdlib.c
@@ -237,6 +237,17 @@ int printf(const char *format, ...)
     return cnt;
 }
 
+int sprintf(char *str, const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    int cnt = vsprintf(str, format, args);
+    va_end(args);
+
+    return cnt;
+}
+
 void assert(int cond)
 {
     if (cond) return;

--- a/stdlib.c
+++ b/stdlib.c
@@ -237,17 +237,6 @@ int printf(const char *format, ...)
     return cnt;
 }
 
-int sprintf(char *str, const char *format, ...)
-{
-    va_list args;
-
-    va_start(args, format);
-    int cnt = vsprintf(str, format, args);
-    va_end(args);
-
-    return cnt;
-}
-
 void assert(int cond)
 {
     if (cond) return;

--- a/token.c
+++ b/token.c
@@ -1,11 +1,10 @@
 #include "aqcc.h"
 
-Token *new_token(int kind, int line, int column)
+Token *new_token(int kind, Source *source)
 {
     Token *token = (Token *)safe_malloc(sizeof(Token));
     token->kind = kind;
-    token->line = line;
-    token->column = column;
+    token->source = source;
     return token;
 }
 

--- a/utility.c
+++ b/utility.c
@@ -15,13 +15,15 @@ _Noreturn void error(const char *msg, ...)
 
 _Noreturn void error_unexpected_token_kind(int expect_kind, Token *got)
 {
-    error(":%d:%d: unexpected token: expect %s, got %s", got->line, got->column,
+    error("%s:%d:%d: unexpected token: expect %s, got %s",
+          got->source->filepath, got->source->line, got->source->column,
           token_kind2str(expect_kind), token_kind2str(got->kind));
 }
 
 _Noreturn void error_unexpected_token_str(char *expect_str, Token *got)
 {
-    error(":%d:%d: unexpected token: expect %s, got %s", got->line, got->column,
+    error("%s:%d:%d: unexpected token: expect %s, got %s",
+          got->source->filepath, got->source->line, got->source->column,
           expect_str, token_kind2str(got->kind));
 }
 

--- a/utility.c
+++ b/utility.c
@@ -226,13 +226,13 @@ void erase_backslash_newline(char *src)
 Vector *read_tokens_from_filepath(char *filepath)
 {
     char *src = read_entire_file(filepath);
-    return read_all_tokens(src);
+    return read_all_tokens(src, filepath);
 }
 
 Vector *read_asm_from_filepath(char *filepath)
 {
     char *src = read_entire_file(filepath);
-    return read_all_asm(src);
+    return read_all_asm(src, filepath);
 }
 
 int is_register_code(Code *code)


### PR DESCRIPTION
コンパイルしているソースコードが存在しているディレクトリを表す、`cwd` の概念を導入しました.
それにより
* `#include "aqcc.h"` が ソースコードのカレントディレクトリ基準で処理され、 `./aqcc.h` という扱いになる.
* エラーメッセージの多くが `test.c:1:2 (エラーの内容)` という形式になる.
* `examples` 以下が動作するようになる.
* この際必要であった `sprintf()` を `stdlib.c` に実装.