### PR TITLE
シェルをshからbashに変更する

### DIFF
--- a/aqcc
+++ b/aqcc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z $AQCC_DETAIL ]
 then

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export AQCC_DETAIL=./aqcc_detail
 


### PR DESCRIPTION
`sh` は `function f ()` 構文や配列をサポートしていないため、 (環境によっては) `make test` でエラーが出ます

```
./test.sh
./test.sh: 5: ./test.sh: Syntax error: "(" unexpected
Makefile:14: recipe for target 'test' failed
make: *** [test] Error 2
```

`test.sh` を修正した後、 `aqcc` で配列を使っている部分でもエラーが出ました

このプルリクエストでは bash を指定することで解決しています (他の解決策もあると思います)

環境: Ubuntu 18.04