### PR TITLE
stdlib: delete unused variable in malloc()

### DIFF
--- a/as/stdlib.c
+++ b/as/stdlib.c
@@ -128,9 +128,7 @@ void *malloc(int size)
     if (malloc_pointer_head == 0) {
         char *p = brk(0);
         int size = 0x32000000;
-        char *q = brk(p + size);
         // printf("init %d\n", p);
-        // printf("init %d\n", q);
         malloc_pointer_head = p;
         malloc_remaining_size = size;
     }

--- a/as/stdlib.c
+++ b/as/stdlib.c
@@ -129,7 +129,6 @@ void *malloc(int size)
         char *p = brk(0);
         int size = 0x32000000;
         brk(p + size);
-        // printf("init %d\n", p);
         malloc_pointer_head = p;
         malloc_remaining_size = size;
     }
@@ -143,11 +142,6 @@ void *malloc(int size)
     char *ret = malloc_pointer_head + 4;
     malloc_pointer_head += size + 4;
     malloc_remaining_size -= size + 4;
-
-    // printf("%d\n", malloc_remaining_size);
-    // printf("%d\n", size);
-    // printf("%d\n", ret);
-    // printf("%d\n", ret + size);
     return ret;
 }
 

--- a/as/stdlib.c
+++ b/as/stdlib.c
@@ -128,6 +128,7 @@ void *malloc(int size)
     if (malloc_pointer_head == 0) {
         char *p = brk(0);
         int size = 0x32000000;
+        brk(p + size);
         // printf("init %d\n", p);
         malloc_pointer_head = p;
         malloc_remaining_size = size;

--- a/cc/stdlib.c
+++ b/cc/stdlib.c
@@ -128,9 +128,7 @@ void *malloc(int size)
     if (malloc_pointer_head == 0) {
         char *p = brk(0);
         int size = 0x32000000;
-        char *q = brk(p + size);
         // printf("init %d\n", p);
-        // printf("init %d\n", q);
         malloc_pointer_head = p;
         malloc_remaining_size = size;
     }

--- a/cc/stdlib.c
+++ b/cc/stdlib.c
@@ -129,7 +129,6 @@ void *malloc(int size)
         char *p = brk(0);
         int size = 0x32000000;
         brk(p + size);
-        // printf("init %d\n", p);
         malloc_pointer_head = p;
         malloc_remaining_size = size;
     }
@@ -143,11 +142,6 @@ void *malloc(int size)
     char *ret = malloc_pointer_head + 4;
     malloc_pointer_head += size + 4;
     malloc_remaining_size -= size + 4;
-
-    // printf("%d\n", malloc_remaining_size);
-    // printf("%d\n", size);
-    // printf("%d\n", ret);
-    // printf("%d\n", ret + size);
     return ret;
 }
 

--- a/cc/stdlib.c
+++ b/cc/stdlib.c
@@ -128,6 +128,7 @@ void *malloc(int size)
     if (malloc_pointer_head == 0) {
         char *p = brk(0);
         int size = 0x32000000;
+        brk(p + size);
         // printf("init %d\n", p);
         malloc_pointer_head = p;
         malloc_remaining_size = size;

--- a/ld/stdlib.c
+++ b/ld/stdlib.c
@@ -128,9 +128,7 @@ void *malloc(int size)
     if (malloc_pointer_head == 0) {
         char *p = brk(0);
         int size = 0x32000000;
-        char *q = brk(p + size);
         // printf("init %d\n", p);
-        // printf("init %d\n", q);
         malloc_pointer_head = p;
         malloc_remaining_size = size;
     }

--- a/ld/stdlib.c
+++ b/ld/stdlib.c
@@ -129,7 +129,6 @@ void *malloc(int size)
         char *p = brk(0);
         int size = 0x32000000;
         brk(p + size);
-        // printf("init %d\n", p);
         malloc_pointer_head = p;
         malloc_remaining_size = size;
     }
@@ -143,11 +142,6 @@ void *malloc(int size)
     char *ret = malloc_pointer_head + 4;
     malloc_pointer_head += size + 4;
     malloc_remaining_size -= size + 4;
-
-    // printf("%d\n", malloc_remaining_size);
-    // printf("%d\n", size);
-    // printf("%d\n", ret);
-    // printf("%d\n", ret + size);
     return ret;
 }
 

--- a/ld/stdlib.c
+++ b/ld/stdlib.c
@@ -128,6 +128,7 @@ void *malloc(int size)
     if (malloc_pointer_head == 0) {
         char *p = brk(0);
         int size = 0x32000000;
+        brk(p + size);
         // printf("init %d\n", p);
         malloc_pointer_head = p;
         malloc_remaining_size = size;


### PR DESCRIPTION
```
char *q = brk(p + size);
```
This `q` is not needed.